### PR TITLE
Fix installation on Fedora Silverblue/Kinoite

### DIFF
--- a/scripts/flatpak-setup.sh
+++ b/scripts/flatpak-setup.sh
@@ -2,9 +2,12 @@
 
 # Fedora Atomic editions like Silverblue or Kinoite have /usr read-only
 INSTALL_DIR="/usr/lib"
+ATOMIC=0
 if grep -E "Silverblue|Kinoite" "/etc/os-release" >> /dev/null; then
     INSTALL_DIR="/etc"
+    ATOMIC=1
 fi
+#echo $INSTALL_DIR && exit 0
 
 # Function to handle uninstallation
 uninstall() {
@@ -202,6 +205,9 @@ if groups "$USER" | grep &>/dev/null '\bvideo\b'; then
     echo "User $USER is already in the video group."
 else
     echo "Adding user $USER to the video group..."
+    if [ $ATOMIC = 1 ]; then
+        grep -E '^video:' /usr/lib/group | sudo tee -a /etc/group
+    fi
     sudo usermod -aG video "$USER"
     echo "PLEASE NOTE: You may need to log out and log back in for group changes to take effect."
 fi


### PR DESCRIPTION
The first commit sets the installation directory for the [hwdb](https://www.freedesktop.org/software/systemd/man/latest/hwdb.html#Hardware%20Database%20Files) and [udev](https://www.freedesktop.org/software/systemd/man/latest/udev.html#Rules%20Files) rules to `/etc` as `/usr` is read-only on Fedora [Atomic](https://docs.fedoraproject.org/de/atomic-desktops/technical-information/#filesystem-layout). Fixes #44 
Maybe it should be considered unconditionally as #45 suggests.

The second commit adds a workaround for adding users to groups as described at the [docs](https://docs.fedoraproject.org/en-US/atomic-desktops/troubleshooting/#_unable_to_add_user_to_group)

